### PR TITLE
Enable prometheus scraping for just R hub

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -94,6 +94,9 @@ jupyterhub:
         tag: 12.2
         policy: IfNotPresent
   singleuser:
+    extraAnnotations:
+      # We scrape only every 5 minutes, to not overwhelm the prometheus server
+      prometheus.io/scrape-slow: "true"
     extraContainers:
       - name: postgres
         image: gcr.io/ucb-datahub-2018/jupyterhub-postgres:0.0.1-n2510.hd28e63b

--- a/deployments/r/config/common.yaml
+++ b/deployments/r/config/common.yaml
@@ -48,6 +48,10 @@ jupyterhub:
           # List of other admin users
 
   singleuser:
+    extraAnnotations:
+      # Enable prometheus scraping just for R hub
+      # We scrape only every 5 minutes, to not overwhelm the prometheus server
+      prometheus.io/scrape-slow: "true"
     nodeSelector:
       hub.jupyter.org/pool-name: gamma-pool
     storage:


### PR DESCRIPTION
I think enabling it for all of datahub overwhelms our single
prometheus instance - although the weekend prometheus outage
was caused by my misunderstanding of how network policies work.

Let's slowly enable these metrics. R Hub has enough users to
test this out, but hopefully not so much that it overwhelms the
server. We also scrape every 5min (with `scrape-slow`) instead of
1m.